### PR TITLE
Corrected fetch URL for golang.org extended packages

### DIFF
--- a/src/grapnel/cmd/config.go
+++ b/src/grapnel/cmd/config.go
@@ -23,6 +23,6 @@ THE SOFTWARE.
 */
 
 var (
-  PROGRAM_NAME string = "grapnel"
-  VERSION string = "0.4"
+	PROGRAM_NAME string = "grapnel"
+	VERSION      string = "0.4"
 )

--- a/src/grapnel/cmd/install.go
+++ b/src/grapnel/cmd/install.go
@@ -24,8 +24,8 @@ THE SOFTWARE.
 
 import (
 	"fmt"
-	. "grapnel/lib"
 	. "grapnel/flag"
+	. "grapnel/lib"
 	log "grapnel/log"
 	"os"
 )

--- a/src/grapnel/cmd/main.go
+++ b/src/grapnel/cmd/main.go
@@ -24,8 +24,8 @@ THE SOFTWARE.
 
 import (
 	"fmt"
-	. "grapnel/lib"
 	. "grapnel/flag"
+	. "grapnel/lib"
 	log "grapnel/log"
 	"os"
 	"strings"

--- a/src/grapnel/cmd/update.go
+++ b/src/grapnel/cmd/update.go
@@ -24,8 +24,8 @@ THE SOFTWARE.
 
 import (
 	"fmt"
-	. "grapnel/lib"
 	. "grapnel/flag"
+	. "grapnel/lib"
 	log "grapnel/log"
 	"os"
 	"path"

--- a/src/grapnel/grapnel.go
+++ b/src/grapnel/grapnel.go
@@ -27,5 +27,5 @@ import (
 )
 
 func main() {
-  cmd.GrapnelMain()
+	cmd.GrapnelMain()
 }

--- a/src/grapnel/lib/git.go
+++ b/src/grapnel/lib/git.go
@@ -64,7 +64,7 @@ var GitRewriteRules = RewriteRuleArray{
 		"host": `golang.org`,
 		"path": `^/x.*$`,
 	}, StringMap{
-		"host":   `github.org`,
+		"host":   `github.com`,
 		"path":   `{{ replace .path "^/x/(.*)$" "/golang/$1" }}`,
 		"import": `{{ replace .import "^golang.org/x/([^/]*)/(.*)$" "golang.org/x/$1" }}`,
 		"type":   `git`,


### PR DESCRIPTION
Switched to the correct URL target (github.com), as documented in the README, instead of github.org
(which was timing out connections as it is not opening SSL port...).
